### PR TITLE
view-injection v1.1.1 added kapt for dagger (fixed multimodule build)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ ext.versions = [
         viewUIName           : '1.1.0',
         viewReduxName        : '1.3.0',
         viewNavigationName   : '1.1.0',
-        viewInjectionName    : '1.1.0',
+        viewInjectionName    : '1.1.1',
 
         presentationBaseName : '1.1.1',
         presentationReduxName: '1.3.0',
@@ -33,7 +33,7 @@ ext.versions = [
         cicerone            : '7.1',
 
         // dagger
-        dagger              : '2.40',
+        dagger              : '2.41',
 
         // rx
         rxJava2             : '2.2.21',

--- a/view/view-injection/build.gradle
+++ b/view/view-injection/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'maven-publish'
 
 android {
@@ -26,6 +27,7 @@ android {
 dependencies {
     implementation libraries.kotlin
     api libraries.dagger
+    kapt libraries.daggerCompiler
 
     api libraries.archCompiler
     api libraries.archViewModel


### PR DESCRIPTION
- Фикс для случая многомодульного приложения, в котором несколько модулей или библиотек используют view-injection. Без этого фикса при попытке собрать релизную версию приложения, возникает ошибка с сообщением о multiple types (или multiple files) DaggerViewModelFactory_Factory.